### PR TITLE
Add conditional check and skip configuration if value not provide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.molecule

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,3 +8,4 @@
 - include_tasks: config.yml
   tags:
     - storage-config
+  when: lvm_volumes is defined and lvm_vgs is defined


### PR DESCRIPTION
Skip applying config if values `lvm_vgs` and `lvm_volumes` were not defined.